### PR TITLE
Cache/retrieve user info retrieved from LMS User API in memcached

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argparse==1.2.1
 certifi==14.05.14
 pyinotify==0.9.4
+python-memcached==1.59
 requests==2.4.0
 wsgiref==0.1.2
 edx_rest_api_client==1.8.2

--- a/xapi_bridge/settings-dist.py
+++ b/xapi_bridge/settings-dist.py
@@ -16,6 +16,9 @@ OPENEDX_USER_API_URI = OPENEDX_PLATFORM_URI + "/api/user/v1/"
 OPENEDX_OAUTH2_CLIENT_ID = "foo"
 OPENEDX_OAUTH2_CLIENT_SECRET = "notasecret"
 
+LMS_API_USE_MEMCACHED = False
+MEMCACHED_ADDRESS = "127.0.0.1:11211"
+
 # events configuration
 # list of ignored event ids
 IGNORED_EVENT_TYPES = []


### PR DESCRIPTION
We don't want to hit the LMS User API every time, so cache retrieved user name and email address values by username key.