### PR TITLE
Fixes and configuration for pyinotify polling

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 argparse==1.2.1
 certifi==14.05.14
 edx_rest_api_client==1.8.2
-pyinotify==0.9.4
+pyinotify==0.9.6
 python-memcached==1.59
 requests==2.4.0
 six

--- a/xapi_bridge/__main__.py
+++ b/xapi_bridge/__main__.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 import logging
 import os
+import signal
 import sys
 import threading
 import time
@@ -188,6 +189,19 @@ def watch(watch_file):
         watch(watch_file)
     finally:
         logger.info('Exiting watch')
+
+
+def signal_terminate_handler(signum, frame):
+    """Handle terminating signals from terminal or sysctl to properly shut down."""
+    if settings.HTTP_PUBLISH_STATUS is True:
+        logger.info("Shutting down http server")
+        server.httpd.server_close()
+        time.sleep(1)
+    raise
+
+
+for sig in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM, signal.SIGABRT):
+    signal.signal(sig, signal_terminate_handler)
 
 
 if __name__ == '__main__':

--- a/xapi_bridge/__main__.py
+++ b/xapi_bridge/__main__.py
@@ -199,8 +199,10 @@ def signal_terminate_handler(signum, frame):
     """Handle terminating signals from terminal or sysctl to properly shut down."""
     if settings.HTTP_PUBLISH_STATUS is True:
         logger.info("Shutting down http server")
-        server.httpd.server_close()
-        time.sleep(1)
+        http_server.shutdown()
+        http_server.socket.close()
+        thread.join(2.0)
+
     raise SystemExit
 
 
@@ -226,7 +228,8 @@ if __name__ == '__main__':
     if settings.HTTP_PUBLISH_STATUS is True:
         # open a TCP socket and HTTP server for simple OK status response
         # for service uptime monitoring
-        thread = threading.Thread(target=server.httpd.serve_forever)
+        http_server = server.httpd
+        thread = threading.Thread(target=http_server.serve_forever)
         thread.daemon = True
         thread.start()
 

--- a/xapi_bridge/__main__.py
+++ b/xapi_bridge/__main__.py
@@ -197,7 +197,7 @@ def signal_terminate_handler(signum, frame):
         logger.info("Shutting down http server")
         server.httpd.server_close()
         time.sleep(1)
-    raise
+    raise SystemExit
 
 
 for sig in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM, signal.SIGABRT):
@@ -219,30 +219,23 @@ if __name__ == '__main__':
         level=logging.INFO
         )
 
-    try:
-        if settings.HTTP_PUBLISH_STATUS is True:
-            # open a TCP socket and HTTP server for simple OK status response
-            # for service uptime monitoring
-            thread = threading.Thread(target=server.httpd.serve_forever)
-            thread.daemon = True
-            thread.start()
+    if settings.HTTP_PUBLISH_STATUS is True:
+        # open a TCP socket and HTTP server for simple OK status response
+        # for service uptime monitoring
+        thread = threading.Thread(target=server.httpd.serve_forever)
+        thread.daemon = True
+        thread.start()
 
-        # try to connect to the LRS immediately
-        lrs = client.lrs
-        resp = lrs.about()
-        if resp.success:
-            logger.info('Successfully connected to remote LRS at {}. Described by {}'.format(settings.LRS_ENDPOINT, resp.data))
-            logger.debug(resp.data)
-        else:
-            e = exceptions.XAPIBridgeLRSConnectionError(resp)
-            e.err_fail()
+    # try to connect to the LRS immediately
+    lrs = client.lrs
+    resp = lrs.about()
+    if resp.success:
+        logger.info('Successfully connected to remote LRS at {}. Described by {}'.format(settings.LRS_ENDPOINT, resp.data))
+        logger.debug(resp.data)
+    else:
+        e = exceptions.XAPIBridgeLRSConnectionError(resp)
+        e.err_fail()
 
-        log_path = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else '/edx/var/log/tracking/tracking.log'
-        logger.debug('Watching file {}, starting time {}'.format(log_path, str(datetime.now())))
-        watch(log_path)
-    except (SystemExit, KeyboardInterrupt):
-        if settings.HTTP_PUBLISH_STATUS is True:
-            logger.info("Shutting down http server")
-            server.httpd.server_close()
-            time.sleep(1)
-        raise
+    log_path = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else '/edx/var/log/tracking/tracking.log'
+    logger.debug('Watching file {}, starting time {}'.format(log_path, str(datetime.now())))
+    watch(log_path)

--- a/xapi_bridge/__main__.py
+++ b/xapi_bridge/__main__.py
@@ -165,10 +165,12 @@ class TailHandler(ProcessEvent):
 
     def process_IN_MOVE_SELF(self, event):
         """Handle moved tracking log file; e.g., during log rotation."""
+        logger.info("caught inotify IN_MOVE_SELF (tracking log file moved)")
         raise NotifierLostINodeException()
 
     def process_IN_DELETE_SELF(self, event):
         """Handle deletion of tracking log file e.g., during log rotation."""
+        logger.info("caught inotify IN_DELETE_SELF (tracking log file deleted)")
         raise NotifierLostINodeException()
 
 
@@ -185,7 +187,7 @@ def watch(watch_file):
             notifier.loop()
     except NotifierLostINodeException:
         # end and restart watch
-        notifier.stop()
+        notifier.stop()  # close inotify instance
         watch(watch_file)
     finally:
         logger.info('Exiting watch')

--- a/xapi_bridge/__main__.py
+++ b/xapi_bridge/__main__.py
@@ -165,13 +165,15 @@ class TailHandler(ProcessEvent):
 
     def process_IN_MOVE_SELF(self, event):
         """Handle moved tracking log file; e.g., during log rotation."""
-        logger.info("caught inotify IN_MOVE_SELF (tracking log file moved)")
-        raise NotifierLostINodeException()
+        msg = "caught inotify IN_MOVE_SELF (tracking log file moved)"
+        logger.info(msg)
+        raise NotifierLostINodeException(msg)
 
     def process_IN_DELETE_SELF(self, event):
         """Handle deletion of tracking log file e.g., during log rotation."""
-        logger.info("caught inotify IN_DELETE_SELF (tracking log file deleted)")
-        raise NotifierLostINodeException()
+        msg = "caught inotify IN_DELETE_SELF (tracking log file deleted)"
+        logger.info(msg)
+        raise NotifierLostINodeException(msg)
 
 
 def watch(watch_file):

--- a/xapi_bridge/__main__.py
+++ b/xapi_bridge/__main__.py
@@ -155,10 +155,10 @@ def watch(watch_file):
 
     with TailHandler(watch_file) as th:
 
-        notifier = Notifier(wm, th)
+        notifier = Notifier(wm, th, read_freq=settings.NOTIFIER_READ_FREQ, timeout=settings.NOTIFIER_POLL_TIMEOUT)
         wm.add_watch(watch_file, TailHandler.MASK)
 
-        notifier.loop()
+        notifier.loop(daemonize=True)
 
         # flush queue before exiting
         th.publish_queue.publish()

--- a/xapi_bridge/settings-dist.py
+++ b/xapi_bridge/settings-dist.py
@@ -8,6 +8,15 @@ PUBLISH_MAX_PAYLOAD = 10
 # maximum publish retries on LRS connection error
 PUBLISH_MAX_RETRIES = 1
 
+# sleep time between polls of watched log file, in seconds
+NOTIFIER_READ_FREQ = 2
+
+# how long to wait for activity when polling, in milliseconds
+# https://docs.python.org/2.4/lib/poll-objects.html
+# If timeout is omitted, negative, or None, the call will block until
+# there is an event for this poll object.
+NOTIFIER_POLL_TIMEOUT = 1000
+
 # lrs credentials
 LRS_ENDPOINT = 'https://lrs.adlnet.gov/xAPI/'
 LRS_USERNAME = 'fakeuser'


### PR DESCRIPTION
The main fix here is to include IN_CREATE and IN_MOVED_TO to the event mask, so that log rotation of the tracking log doesn't kill the event polling.  

Update to latest release of pyinotify

Add configuration options for pyinotify notifier polling timeout and a sleep delay in times between polls of the log file.  